### PR TITLE
data: refresh Environment (+ new MOSPI energy-supply section)

### DIFF
--- a/public/data/environment/2025-26/energy.json
+++ b/public/data/environment/2025-26/energy.json
@@ -491,5 +491,34 @@
       "smallHydro": 5011
     }
   ],
-  "source": "World Bank + CEA Installed Capacity Reports"
+  "energySupply": [
+    {
+      "commodity": "Coal",
+      "commodityCode": "coal",
+      "year": "2023-24",
+      "production": 403799.5,
+      "imports": 141638.8,
+      "totalSupply": 534098.3,
+      "unit": "KToE"
+    },
+    {
+      "commodity": "Natural Gas",
+      "commodityCode": "gas",
+      "year": "2023-24",
+      "production": 33704.7,
+      "imports": 29410.3,
+      "totalSupply": 63115.0,
+      "unit": "KToE"
+    },
+    {
+      "commodity": "Lignite",
+      "commodityCode": "lignite",
+      "year": "2023-24",
+      "production": 9786.1,
+      "imports": 11.9,
+      "totalSupply": 9723.0,
+      "unit": "KToE"
+    }
+  ],
+  "source": "MOSPI Energy API (api.mospi.gov.in) + World Bank + CEA Installed Capacity Reports"
 }

--- a/public/data/environment/2025-26/summary.json
+++ b/public/data/environment/2025-26/summary.json
@@ -6,6 +6,6 @@
   "pm25": 53.3,
   "coalPct": 48.8,
   "ghgTotal": 3347.9,
-  "lastUpdated": "2026-04-15",
+  "lastUpdated": "2026-06-02",
   "source": "World Bank + CPCB + ISFR 2023 + CEA + CWC + CGWB"
 }


### PR DESCRIPTION
Data-only refresh. **Structural change (guard-flagged):** `energy.json` gains a new top-level `energySupply` section from the now-reachable **MOSPI Energy API** (source line updated). This is a **new data block on the site** — a feature gain, not a regression — so it's flagged for your eyes. Review the new section, then merge at will.