### PR TITLE
design: craft fixes batch 1 — text-wrap balance + reduced-motion gating

### DIFF
--- a/src/components/ui/NarrativeBridge.tsx
+++ b/src/components/ui/NarrativeBridge.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { motion, useScroll, useTransform } from 'framer-motion';
+import { motion, useScroll, useTransform, useReducedMotion } from 'framer-motion';
 
 interface NarrativeBridgeProps {
   text: string;
@@ -60,14 +60,19 @@ function WordReveal({
   const start = index / (total + 3);
   const end = Math.min((index + 4) / (total + 3), 1);
 
+  const prefersReducedMotion = useReducedMotion();
   const opacity = useTransform(progress, [start, end], [0.12, 1]);
   const y = useTransform(progress, [start, end], [6, 0]);
 
+  // Honor reduced-motion: skip the scroll-driven word reveal (opacity + y
+  // movement) and render the text statically. CSS `prefers-reduced-motion`
+  // cannot stop Framer's `useTransform`, so this must be gated in JS.
+  const style = prefersReducedMotion
+    ? { display: 'inline-block', color: color || undefined }
+    : { opacity, y, display: 'inline-block', color: color || undefined };
+
   return (
-    <motion.span
-      style={{ opacity, y, display: 'inline-block', color: color || undefined }}
-      className="mr-[0.3em]"
-    >
+    <motion.span style={style} className="mr-[0.3em]">
       {word}
     </motion.span>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -174,6 +174,7 @@
     font-weight: 800;
     line-height: 1;
     letter-spacing: -0.02em;
+    text-wrap: balance;
   }
 
   .text-composition {
@@ -181,6 +182,7 @@
     font-weight: 700;
     line-height: 1.2;
     letter-spacing: -0.01em;
+    text-wrap: balance;
   }
 
   .text-stat {

--- a/src/lib/svgCapture.ts
+++ b/src/lib/svgCapture.ts
@@ -94,7 +94,7 @@ function prepareSvgClone(svg: SVGSVGElement): SVGSVGElement {
 // ─── Font Embedding ──────────────────────────────────────────────────
 
 function createFontStyleElement(): string {
-  // Use web-safe fallback fonts. The exported image won't have Inter/JetBrains Mono
+  // Use web-safe fallback fonts. The exported image won't have Source Sans 3/JetBrains Mono
   // loaded unless the user's browser has them. For a clean export, we map to
   // system fonts that are reliably available on Canvas.
   return `


### PR DESCRIPTION
First batch of the web-design pipeline pass — **safe, no-taste craft fixes** (Stages 6/8/10):

- **`text-wrap: balance`** on `.text-hero` / `.text-composition` — no more orphan words in display headings. (Progressive enhancement; graceful fallback on old browsers.)
- **Reduced-motion gating** for NarrativeBridge's scroll word-reveal — the CSS `prefers-reduced-motion` block couldn't stop Framer's `useTransform` `y`-movement, so vestibular users still got it; now gated via `useReducedMotion()`. (Header's scroll fade is opacity-only → not a motion concern → unchanged.)
- Fixed a stale "Inter" code comment (site uses Source Sans 3).

**Two audit gaps turned out FALSE on inspection and were NOT changed:** contrast (`--text-muted #7a8a9e` passes WCAG AA at 5.68/5.23/4.53:1) and the "Inter font conflict" (the site already ships Source Sans 3 + JetBrains Mono via @fontsource).

Verified: tsc + vite build clean, all 80 routes prerender. The Vercel PR preview gives a live visual check of the heading balancing. Nothing merged — review at will.