### PR TITLE
data(environment): forest %, coal %, CEA 2024 mix, MP/CG forest area (double-verified)

### DIFF
--- a/pipeline/src/environment/sources/curated.py
+++ b/pipeline/src/environment/sources/curated.py
@@ -113,9 +113,9 @@ CPCB_AQI_CITIES = [
 # Verified 2026-03-05 by reading every state chapter from the 382-page PDF.
 
 FSI_FOREST_STATES = [
-    {"id": "MP", "name": "Madhya Pradesh", "forestCoverKm2": 77073, "pctGeographicArea": 25.11, "changeKm2": -371.54},
+    {"id": "MP", "name": "Madhya Pradesh", "forestCoverKm2": 77073, "pctGeographicArea": 25.00, "changeKm2": -371.54},
     {"id": "AR", "name": "Arunachal Pradesh", "forestCoverKm2": 65882, "pctGeographicArea": 78.67, "changeKm2": -91.17},
-    {"id": "CG", "name": "Chhattisgarh", "forestCoverKm2": 55812, "pctGeographicArea": 41.21, "changeKm2": -19.13},
+    {"id": "CG", "name": "Chhattisgarh", "forestCoverKm2": 55812, "pctGeographicArea": 41.28, "changeKm2": -19.13},
     {"id": "MH", "name": "Maharashtra", "forestCoverKm2": 50859, "pctGeographicArea": 16.53, "changeKm2": -54.47},
     {"id": "OD", "name": "Odisha", "forestCoverKm2": 52434, "pctGeographicArea": 33.68, "changeKm2": 151.89},
     {"id": "KA", "name": "Karnataka", "forestCoverKm2": 39254, "pctGeographicArea": 20.47, "changeKm2": 147.70},
@@ -199,8 +199,8 @@ CEA_ENERGY_MIX = [
     },
     {
         "year": "2024",
-        "coal": 213950, "gas": 24824, "nuclear": 7480, "hydro": 47073,
-        "solar": 82788, "wind": 46160, "biomass": 10544, "smallHydro": 5011,
+        "coal": 210969, "gas": 25038, "nuclear": 8180, "hydro": 46928,
+        "solar": 81814, "wind": 46160, "biomass": 10544, "smallHydro": 5011,
     },
 ]
 
@@ -269,9 +269,9 @@ CGWB_GROUNDWATER_STATES = [
 
 NATIONAL_TOTALS = {
     "co2PerCapita": 1.9,                # tonnes, World Bank 2021
-    "forestPct": 25.17,                  # ISFR 2023
+    "forestPct": 21.76,                  # ISFR 2023 forest cover (7,15,343 km2). NOTE: 25.17% is forest+TREE cover; forest cover alone is 21.76%.
     "renewablesPct": 43.4,              # CEA Mar 2024 (solar+wind+hydro+bio+smallHydro / total)
     "pm25": 53.3,                        # μg/m3, World Bank 2021
-    "coalPct": 48.8,                    # CEA Mar 2024 (coal / total installed capacity)
+    "coalPct": 47.73,                   # CEA 31.03.2024 (coal-only / 441,970 MW grand total)
     "ghgTotal": 3347.9,                 # Mt CO2e, World Bank 2021
 }

--- a/public/data/environment/2025-26/energy.json
+++ b/public/data/environment/2025-26/energy.json
@@ -481,11 +481,11 @@
     },
     {
       "year": "2024",
-      "coal": 213950,
-      "gas": 24824,
-      "nuclear": 7480,
-      "hydro": 47073,
-      "solar": 82788,
+      "coal": 210969,
+      "gas": 25038,
+      "nuclear": 8180,
+      "hydro": 46928,
+      "solar": 81814,
       "wind": 46160,
       "biomass": 10544,
       "smallHydro": 5011

--- a/public/data/environment/2025-26/forest.json
+++ b/public/data/environment/2025-26/forest.json
@@ -255,7 +255,7 @@
       "id": "MP",
       "name": "Madhya Pradesh",
       "forestCoverKm2": 77073,
-      "pctGeographicArea": 25.11,
+      "pctGeographicArea": 25.0,
       "changeKm2": -371.54
     },
     {
@@ -269,7 +269,7 @@
       "id": "CG",
       "name": "Chhattisgarh",
       "forestCoverKm2": 55812,
-      "pctGeographicArea": 41.21,
+      "pctGeographicArea": 41.28,
       "changeKm2": -19.13
     },
     {

--- a/public/data/environment/2025-26/indicators.json
+++ b/public/data/environment/2025-26/indicators.json
@@ -169,7 +169,7 @@
         {
           "id": "MP",
           "name": "Madhya Pradesh",
-          "value": 25.11
+          "value": 25.0
         },
         {
           "id": "AR",
@@ -179,7 +179,7 @@
         {
           "id": "CG",
           "name": "Chhattisgarh",
-          "value": 41.21
+          "value": 41.28
         },
         {
           "id": "MH",

--- a/public/data/environment/2025-26/summary.json
+++ b/public/data/environment/2025-26/summary.json
@@ -1,11 +1,11 @@
 {
   "year": "2025-26",
   "co2PerCapita": 1.9,
-  "forestPct": 25.17,
+  "forestPct": 21.76,
   "renewablesPct": 43.4,
   "pm25": 53.3,
-  "coalPct": 48.8,
+  "coalPct": 47.73,
   "ghgTotal": 3347.9,
-  "lastUpdated": "2026-04-15",
+  "lastUpdated": "2026-06-03",
   "source": "World Bank + CPCB + ISFR 2023 + CEA + CWC + CGWB"
 }


### PR DESCRIPTION
Nine data-accuracy fixes, each **independently confirmed by two verification passes** against primary sources (ISFR 2023, CEA 31.03.2024):

- **forestPct 25.17 → 21.76** — 25.17% is forest+*tree* cover; forest cover alone is 21.76% (I personally confirmed via PIB/FSI). The field is forest cover, so it mislabeled the combined figure.
- **coalPct 48.8 → 47.73** (coal-only, CEA grand total).
- **CEA 2024 mix:** nuclear 7480 → **8180** (Kakrapar-4), coal 213950 → 210969, hydro → 46928, gas → 25038, solar → 81814.
- **MP forest area 25.11 → 25.00**, **CG 41.21 → 41.28**.

Left alone (single-pass only): pm25/ghg/co2PerCapita.

⚠️ **Flagged, not changed:** the **CPCB AQI city/state tables aren't traceable to any CPCB source** (both passes) — looks like IQAir/WHO city data mislabeled as CPCB. Needs sourcing or removal — your call; I didn't silently delete a visible feature.

Regenerated data; diff is exactly these corrections. Part of the site-wide data-accuracy audit.