### PR TITLE
data(elections): rebuild contaminated ADR top-criminal list + remove fabricated median assets

### DIFF
--- a/pipeline/src/elections/sources/curated.py
+++ b/pipeline/src/elections/sources/curated.py
@@ -295,7 +295,11 @@ ADR_SUMMARY = {
     },
     "assets": {
         "avgCrore": 46.34,    # Average declared assets (ADR 2024 Lok Sabha report)
-        "medianCrore": 29.8,  # Median (better central tendency given skew)
+        # NOTE: ADR publishes ONLY the average (Rs 46.34 cr) for the 543 winners,
+        # not a median. The previous medianCrore=29.8 was unsourced/fabricated and
+        # has been removed (both 2026-06 verification passes + ADR press release /
+        # crorepati analysis confirm no published median). Do not reintroduce
+        # without a primary ADR figure.
     },
     "education": {
         "postGradAndAbove": 37,   # % with post-graduate or higher
@@ -324,29 +328,28 @@ ADR_TOP_WEALTHIEST = [
     {"rank": 10, "name": "Dr. Prabha Mallikarjun", "constituency": "Davanagere (KA)", "party": "INC", "assetsCrore": 241},
 ]
 
-# Top MPs by number of criminal cases (2024 winning candidates only)
-# Source: ADR/MyNeta — from self-sworn affidavits of 543 winners
+# Top MPs by number of declared criminal cases (2024 winning candidates only)
+# Source: ADR / MyNeta — self-sworn affidavits of the 543 Lok Sabha 2024 winners,
+#         "Winners with declared criminal cases" sorted by number of cases.
+#         myneta.info/LokSabha2024 (winner crime analysis).
 #
-# NOTE (audit 2026-03-05): Heavy contamination found — 5 of original 15 entries
-# were NOT 2024 Lok Sabha winners:
-#   - Atul Kumar Singh (BSP): lost Ghosi to SP's Rajeev Rai
-#   - Omprakash Rajbhar (SBSP): not a candidate (son Arvind lost Ghosi)
-#   - Dinesh Lal Yadav Nirahua (BJP): lost Azamgarh to SP's Dharmendra Yadav
-#   - Anant Kumar Hegde (BJP): didn't get ticket (replaced by Kageri)
-#   - Hemant Soren (JMM): didn't contest (Nalin Soren won Dumka for JMM)
-# Fixes applied: Dean Kuriakose cases 149→204, Afzal Ansari party BSP→SP.
-# Remaining entries need verification against ADR PDF.
+# REBUILT 2026-06: The prior list was heavily contaminated — only Pappu Yadav was a
+# genuine entry (and at the wrong rank), ranks 2-4 of the real list were absent, and
+# several rows carried wrong party/constituency. Rank-1 case count was also wrong
+# (204 → 88 per the MyNeta affidavit). Rebuilt from the MyNeta winners-by-criminal-
+# cases ranking; double-confirmed across both 2026-06 verification passes.
+# Note: ranks 6 and 7 are tied at 36 cases (MyNeta listing order preserved).
 ADR_TOP_CRIMINAL = [
-    {"rank": 1, "name": "Dean Kuriakose", "constituency": "Idukki (KL)", "party": "INC", "cases": 204},
-    {"rank": 2, "name": "Dhairyasheel Mane", "constituency": "Hatkanangle (MH)", "party": "SS(UBT)", "cases": 43},
-    {"rank": 3, "name": "Afzal Ansari", "constituency": "Ghazipur (UP)", "party": "SP", "cases": 42},
-    {"rank": 4, "name": "Rajesh Ranjan (Pappu Yadav)", "constituency": "Purnia (BR)", "party": "IND", "cases": 41},
-    {"rank": 5, "name": "Sunil Kumar Singh", "constituency": "Chatra (JH)", "party": "BJP", "cases": 35},
-    {"rank": 6, "name": "Umesh Singh Kushwaha", "constituency": "Kaushambi (UP)", "party": "SP", "cases": 33},
-    {"rank": 7, "name": "Awadhesh Prasad", "constituency": "Faizabad (UP)", "party": "SP", "cases": 32},
-    {"rank": 8, "name": "Mohan Mandavi", "constituency": "Kanker (CG)", "party": "BJP", "cases": 24},
-    {"rank": 9, "name": "Devendra Singh Bhole", "constituency": "Jaunpur (UP)", "party": "SP", "cases": 23},
-    {"rank": 10, "name": "Lavu Sri Krishna Devarayalu", "constituency": "Narasaraopet (AP)", "party": "TDP", "cases": 22},
+    {"rank": 1, "name": "Dean Kuriakose", "constituency": "Idukki (KL)", "party": "INC", "cases": 88},
+    {"rank": 2, "name": "Shafi Parambil", "constituency": "Vadakara (KL)", "party": "INC", "cases": 47},
+    {"rank": 3, "name": "Eatala Rajender", "constituency": "Malkajgiri (TS)", "party": "BJP", "cases": 45},
+    {"rank": 4, "name": "Bandi Sanjay Kumar", "constituency": "Karimnagar (TS)", "party": "BJP", "cases": 42},
+    {"rank": 5, "name": "Rajesh Ranjan (Pappu Yadav)", "constituency": "Purnia (BR)", "party": "IND", "cases": 41},
+    {"rank": 6, "name": "Dhairyasheel Mohite-Patil", "constituency": "Madha (MH)", "party": "NCP(SP)", "cases": 36},
+    {"rank": 7, "name": "Chandrashekhar Azad", "constituency": "Nagina (UP)", "party": "ASP", "cases": 36},
+    {"rank": 8, "name": "M. Raghunandan Rao", "constituency": "Medak (TS)", "party": "BJP", "cases": 29},
+    {"rank": 9, "name": "Shantanu Thakur", "constituency": "Bangaon (WB)", "party": "BJP", "cases": 23},
+    {"rank": 10, "name": "Dulu Mahato", "constituency": "Dhanbad (JH)", "party": "BJP", "cases": 22},
 ]
 
 

--- a/pipeline/src/elections/transform/candidates.py
+++ b/pipeline/src/elections/transform/candidates.py
@@ -19,10 +19,9 @@ def build_candidates(adr_summary: dict, top_wealthiest: list[dict],
         "pctSerious": adr_summary["criminalCases"]["pctSerious"],
     }
 
-    # Assets distribution
+    # Assets distribution (ADR publishes only the average, not a median)
     assets = {
         "avgCrore": adr_summary["assets"]["avgCrore"],
-        "medianCrore": adr_summary["assets"]["medianCrore"],
     }
 
     # Education breakdown (percentages)

--- a/pipeline/src/elections/validate/schemas.py
+++ b/pipeline/src/elections/validate/schemas.py
@@ -128,7 +128,6 @@ class CriminalBreakdown(BaseModel):
 
 class AssetsBreakdown(BaseModel):
     avgCrore: float
-    medianCrore: float
 
 
 class EducationBreakdown(BaseModel):

--- a/public/data/elections/2025-26/candidates.json
+++ b/public/data/elections/2025-26/candidates.json
@@ -8,8 +8,7 @@
     "pctSerious": 31
   },
   "assets": {
-    "avgCrore": 46.34,
-    "medianCrore": 29.8
+    "avgCrore": 46.34
   },
   "education": {
     "postGradAndAbove": 37,
@@ -94,69 +93,69 @@
       "name": "Dean Kuriakose",
       "constituency": "Idukki (KL)",
       "party": "INC",
-      "cases": 204
+      "cases": 88
     },
     {
       "rank": 2,
-      "name": "Dhairyasheel Mane",
-      "constituency": "Hatkanangle (MH)",
-      "party": "SS(UBT)",
-      "cases": 43
+      "name": "Shafi Parambil",
+      "constituency": "Vadakara (KL)",
+      "party": "INC",
+      "cases": 47
     },
     {
       "rank": 3,
-      "name": "Afzal Ansari",
-      "constituency": "Ghazipur (UP)",
-      "party": "SP",
-      "cases": 42
+      "name": "Eatala Rajender",
+      "constituency": "Malkajgiri (TS)",
+      "party": "BJP",
+      "cases": 45
     },
     {
       "rank": 4,
+      "name": "Bandi Sanjay Kumar",
+      "constituency": "Karimnagar (TS)",
+      "party": "BJP",
+      "cases": 42
+    },
+    {
+      "rank": 5,
       "name": "Rajesh Ranjan (Pappu Yadav)",
       "constituency": "Purnia (BR)",
       "party": "IND",
       "cases": 41
     },
     {
-      "rank": 5,
-      "name": "Sunil Kumar Singh",
-      "constituency": "Chatra (JH)",
-      "party": "BJP",
-      "cases": 35
-    },
-    {
       "rank": 6,
-      "name": "Umesh Singh Kushwaha",
-      "constituency": "Kaushambi (UP)",
-      "party": "SP",
-      "cases": 33
+      "name": "Dhairyasheel Mohite-Patil",
+      "constituency": "Madha (MH)",
+      "party": "NCP(SP)",
+      "cases": 36
     },
     {
       "rank": 7,
-      "name": "Awadhesh Prasad",
-      "constituency": "Faizabad (UP)",
-      "party": "SP",
-      "cases": 32
+      "name": "Chandrashekhar Azad",
+      "constituency": "Nagina (UP)",
+      "party": "ASP",
+      "cases": 36
     },
     {
       "rank": 8,
-      "name": "Mohan Mandavi",
-      "constituency": "Kanker (CG)",
+      "name": "M. Raghunandan Rao",
+      "constituency": "Medak (TS)",
       "party": "BJP",
-      "cases": 24
+      "cases": 29
     },
     {
       "rank": 9,
-      "name": "Devendra Singh Bhole",
-      "constituency": "Jaunpur (UP)",
-      "party": "SP",
+      "name": "Shantanu Thakur",
+      "constituency": "Bangaon (WB)",
+      "party": "BJP",
       "cases": 23
     },
     {
       "rank": 10,
-      "name": "Lavu Sri Krishna Devarayalu",
-      "constituency": "Narasaraopet (AP)",
-      "party": "TDP",
+      "name": "Dulu Mahato",
+      "constituency": "Dhanbad (JH)",
+      "party": "BJP",
       "cases": 22
     }
   ],

--- a/src/lib/data/schema.ts
+++ b/src/lib/data/schema.ts
@@ -1092,7 +1092,6 @@ export interface CriminalBreakdown {
 
 export interface AssetsBreakdown {
   avgCrore: number;
-  medianCrore: number;
 }
 
 export interface EducationBreakdown {


### PR DESCRIPTION
## What & why
Two double-confirmed, primary-sourced data-integrity fixes to the Lok Sabha 2024 ADR/MyNeta candidate-affidavit analysis (`candidates.json`). Both flagged by **both** independent 2026-06 verification passes.

### 1. `topCriminal` (ADR_TOP_CRIMINAL) — rebuilt from primary source
The prior "MPs by criminal cases" ranking was heavily contaminated: only Pappu Yadav was a genuine entry (at the wrong rank), the real ranks 2–4 were missing entirely, and several rows carried wrong party/constituency. Rank-1's case count was also wrong (**204 → 88**).

Rebuilt from MyNeta's *"Winners with declared criminal cases"* ranking — `myneta.info/LokSabha2024`:

| # | MP | Party | Constituency | Cases |
|---|----|-------|--------------|-------|
| 1 | Dean Kuriakose | INC | Idukki (KL) | 88 |
| 2 | Shafi Parambil | INC | Vadakara (KL) | 47 |
| 3 | Eatala Rajender | BJP | Malkajgiri (TS) | 45 |
| 4 | Bandi Sanjay Kumar | BJP | Karimnagar (TS) | 42 |
| 5 | Rajesh Ranjan (Pappu Yadav) | IND | Purnia (BR) | 41 |
| 6 | Dhairyasheel Mohite-Patil | NCP(SP) | Madha (MH) | 36 |
| 7 | Chandrashekhar Azad | ASP | Nagina (UP) | 36 |
| 8 | M. Raghunandan Rao | BJP | Medak (TS) | 29 |
| 9 | Shantanu Thakur | BJP | Bangaon (WB) | 23 |
| 10 | Dulu Mahato | BJP | Dhanbad (JH) | 22 |

(ranks 6 & 7 tie at 36; MyNeta listing order preserved.)

### 2. `assets.medianCrore` (29.8) — removed (fabricated)
ADR publishes only the **average** (₹46.34 cr) for the 543 winners — never a median. The `29.8` value was unsourced/fabricated. Removed from the curated source, transform, Pydantic schema, and the frontend TS type (it was declared but **rendered by no component**, so removal is non-visual).

## Verification
- `candidates.json` regenerated by the elections pipeline; all 7 schemas validate.
- `pytest pipeline/tests/` → **21 passed**.
- Frontend type narrowing verified safe by grep: nothing reads `.medianCrore` (only `assets.avgCrore` is rendered, in `MoneyMuscleSection.tsx`).

## Scope
Branched off `origin/main`. Only `candidates.json` + its 4 pipeline/type source files. Regeneration noise in `summary.json` (date stamp) and `results.json` (pre-existing source/output drift, overlaps #117) was deliberately discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)