### PR TITLE
data(healthcare): correct national TB incidence 199 → 195 per 100k

### DIFF
--- a/pipeline/src/healthcare/sources/curated.py
+++ b/pipeline/src/healthcare/sources/curated.py
@@ -117,5 +117,5 @@ NATIONAL_TOTALS = {
     "healthExpGDP": 3.3,                # World Bank 2021 (latest)
     "outOfPocketPct": 45.1,              # World Bank 2021 (SH.XPD.OOPC.CH.ZS = 45.11)
     "dptImmunization": 91.0,            # World Bank 2023
-    "tbIncidence": 199.0,               # WHO/World Bank 2023, per 100K
+    "tbIncidence": 195.0,               # WHO Global TB Report 2023 (India, per 100K) — was 199
 }

--- a/public/data/healthcare/2025-26/summary.json
+++ b/public/data/healthcare/2025-26/summary.json
@@ -5,7 +5,7 @@
   "healthExpGDP": 3.3,
   "outOfPocketPct": 45.1,
   "dptImmunization": 91.0,
-  "tbIncidence": 199.0,
-  "lastUpdated": "2026-05-15",
+  "tbIncidence": 195.0,
+  "lastUpdated": "2026-06-03",
   "source": "World Bank + National Health Profile 2022 + NFHS-5"
 }


### PR DESCRIPTION
## What & why
The curated national headline **TB incidence** was `199.0` per 100k, labelled *"WHO/World Bank 2023"*. The WHO **Global TB Report 2023** estimate for India is **195 per 100,000** — so the value didn't match its own stated vintage. Corrected `199 → 195`, keeping the 2023 vintage.

Double-confirmed across both independent 2026-06 verification passes.

> Note on vintage: a newer WHO estimate (~187) exists but would require relabeling the field to 2024/2025; per direction we keep the **2023** vintage and use its matching value (195).

## Change
- `pipeline/src/healthcare/sources/curated.py` — `NATIONAL_TOTALS["tbIncidence"]` 199.0 → 195.0
- `public/data/healthcare/2025-26/summary.json` — regenerated

`tbIncidence` is a direct curated passthrough into `summary.json`; the WB-derived `tbIncidenceTimeSeries` (disease.json) is a separate field and is **unchanged**.

## Verification
- summary.json regenerated by the healthcare pipeline with a **live World Bank fetch**; the only data delta is `tbIncidence` (+ `lastUpdated` stamp). WB time series did not drift.
- All 6 healthcare schemas validate; `pytest pipeline/tests/` → **21 passed**.

## Scope
Branched off `origin/main`. Two files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)