### PR TITLE
fix(crime): restore chargesheetRatePct in summary builder (unblocks crime pipeline)

### DIFF
--- a/pipeline/src/crime/main.py
+++ b/pipeline/src/crime/main.py
@@ -181,6 +181,7 @@ def _build_summary() -> dict:
         "totalCrimes": NATIONAL_TOTALS["totalCrimes2022"],
         "crimeRate": NATIONAL_TOTALS["crimeRate2022"],
         "roadDeaths": NATIONAL_TOTALS["roadDeaths2022"],
+        "chargesheetRatePct": NATIONAL_TOTALS["chargesheetRatePct"],
         "convictionRatePct": NATIONAL_TOTALS["convictionRatePct"],
         "womenCrimes": NATIONAL_TOTALS["womenCrimes2022"],
         "cybercrimes": NATIONAL_TOTALS["cybercrimes2022"],


### PR DESCRIPTION
## The bug (§4 in the session handoff)
The `CrimeSummary` Pydantic schema requires `chargesheetRatePct`, but `_build_summary()` in `crime/main.py` had drifted to no longer emit it. Running the crime pipeline fails validation:

```
summary.json FAILED: 1 validation error for CrimeSummary
chargesheetRatePct  ... missing
```

The committed `summary.json` still carried the value (74.6), so the break was **latent** — but it blocks any regeneration and would fail the Crime cron if re-enabled.

## Fix
Emit `chargesheetRatePct` from `NATIONAL_TOTALS` (74.6) in the summary builder, matching the schema and the existing output.

**Code-only:** the regenerated `summary.json` is byte-identical (same value), so no data file is changed.

## Verification
- Before: `python -m src.crime.main` → validation error, `exit(1)`.
- After: `summary.json ✓`, 9 files published.
- `pytest pipeline/tests/` → **21 passed**.

Unblocks the forthcoming NCRB-2023 / MoRTH-2023 crime data refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)