### PR TITLE
design: replace transition-all with explicit transition properties (perf/craft)

### DIFF
--- a/src/components/budget/BudgetVsActualSection.tsx
+++ b/src/components/budget/BudgetVsActualSection.tsx
@@ -125,7 +125,7 @@ export function BudgetVsActualSection({ data }: BudgetVsActualSectionProps) {
               <button
                 key={yr}
                 onClick={() => setSelectedYear(yr)}
-                className="px-3 py-1 rounded-full text-xs font-mono font-medium transition-all cursor-pointer"
+                className="px-3 py-1 rounded-full text-xs font-mono font-medium transition-colors cursor-pointer"
                 style={{
                   background: yr === selectedYear ? 'var(--cyan)' : 'var(--bg-raised)',
                   color: yr === selectedYear ? 'var(--bg-void)' : 'var(--text-muted)',

--- a/src/components/calculator/IncomeInput.tsx
+++ b/src/components/calculator/IncomeInput.tsx
@@ -74,7 +74,7 @@ export function IncomeInput() {
           <button
             key={preset}
             onClick={() => setIncome(preset)}
-            className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-150 cursor-pointer"
+            className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors duration-150 cursor-pointer"
             style={{
               background: income === preset ? 'var(--bg-hover)' : 'var(--bg-raised)',
               color: income === preset ? 'var(--text-primary)' : 'var(--text-secondary)',

--- a/src/components/calculator/ShareCard.tsx
+++ b/src/components/calculator/ShareCard.tsx
@@ -174,7 +174,7 @@ export function ShareCard({ breakdown, regime, shares }: ShareCardProps) {
       <canvas ref={canvasRef} className="hidden" />
       <button
         onClick={handleShare}
-        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-all duration-150 whitespace-nowrap hover:border-[var(--cyan)] hover:bg-[var(--cyan-dim)]"
+        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 whitespace-nowrap hover:border-[var(--cyan)] hover:bg-[var(--cyan-dim)]"
         style={{
           background: status !== 'idle' ? 'var(--positive-dim)' : 'transparent',
           color: status !== 'idle' ? 'var(--positive)' : 'var(--text-secondary)',

--- a/src/components/cost-of-living/CostShareCard.tsx
+++ b/src/components/cost-of-living/CostShareCard.tsx
@@ -161,7 +161,7 @@ export function CostShareCard({ result, fromYear, toYear }: CostShareCardProps) 
       <canvas ref={canvasRef} className="hidden" />
       <button
         onClick={handleShare}
-        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-all duration-150 whitespace-nowrap hover:border-[var(--cyan)] hover:bg-[var(--cyan-dim)]"
+        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 whitespace-nowrap hover:border-[var(--cyan)] hover:bg-[var(--cyan-dim)]"
         style={{
           background: status !== 'idle' ? 'var(--positive-dim)' : 'transparent',
           color: status !== 'idle' ? 'var(--positive)' : 'var(--text-secondary)',

--- a/src/components/emi/EMIShareCard.tsx
+++ b/src/components/emi/EMIShareCard.tsx
@@ -166,7 +166,7 @@ export function EMIShareCard({ breakdown, loanType, loanAmount, tenureYears, rep
       <canvas ref={canvasRef} className="hidden" />
       <button
         onClick={handleShare}
-        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-all duration-150 whitespace-nowrap hover:border-[var(--gold)] hover:bg-[rgba(255,200,87,0.08)]"
+        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 whitespace-nowrap hover:border-[var(--gold)] hover:bg-[rgba(255,200,87,0.08)]"
         style={{
           background: status !== 'idle' ? 'var(--positive-dim)' : 'transparent',
           color: status !== 'idle' ? 'var(--positive)' : 'var(--text-secondary)',

--- a/src/components/explore/DataTable.tsx
+++ b/src/components/explore/DataTable.tsx
@@ -74,7 +74,7 @@ export function DataTable({ data }: DataTableProps) {
         <p className="text-caption">{ministryCount} ministries · {categoryCount} other expenditure heads</p>
         <button
           onClick={exportCSV}
-          className="px-4 py-2 rounded-lg text-sm font-medium cursor-pointer transition-all duration-150 hover:scale-[1.02] hover:border-[var(--saffron)]"
+          className="px-4 py-2 rounded-lg text-sm font-medium cursor-pointer transition-[transform,border-color] duration-150 hover:scale-[1.02] hover:border-[var(--saffron)]"
           style={{
             background: 'var(--bg-raised)',
             color: 'var(--text-secondary)',
@@ -170,7 +170,7 @@ function MinistryRow({
   return (
     <>
       <tr
-        className="cursor-pointer transition-all duration-150 hover:bg-[var(--bg-raised)]"
+        className="cursor-pointer transition-colors duration-150 hover:bg-[var(--bg-raised)]"
         style={{
           borderBottom: 'var(--border-divider)',
           borderLeft: expanded ? '2px solid var(--saffron)' : '2px solid transparent',

--- a/src/components/hub/BuildWithDataSection.tsx
+++ b/src/components/hub/BuildWithDataSection.tsx
@@ -119,7 +119,7 @@ export function BuildWithDataSection() {
             >
               <Link
                 to={card.to}
-                className="group block h-full rounded-xl overflow-hidden no-underline transition-all duration-200 hover:-translate-y-1"
+                className="group block h-full rounded-xl overflow-hidden no-underline transition-[transform,border-color] duration-200 hover:-translate-y-1"
                 style={{
                   background: 'var(--bg-surface)',
                   border: '1px solid rgba(255,255,255,0.04)',

--- a/src/components/hub/CategoryNav.tsx
+++ b/src/components/hub/CategoryNav.tsx
@@ -121,7 +121,7 @@ export function CategoryNav({ sentinelId }: CategoryNavProps) {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay: 0.9, ease: [0.16, 1, 0.3, 1] }}
-      className="sticky z-40 transition-all duration-300 hidden md:block"
+      className="sticky z-40 transition-[backdrop-filter,background-color,border-color] duration-300 hidden md:block"
       style={{
         top: '56px', // below header
         backdropFilter: isStuck ? 'blur(16px)' : 'none',
@@ -150,7 +150,7 @@ export function CategoryNav({ sentinelId }: CategoryNavProps) {
                   <button
                     key={domainId}
                     onClick={() => scrollToDomain(domainId)}
-                    className="shrink-0 px-3 py-1 rounded-full text-xs font-medium transition-all duration-200"
+                    className="shrink-0 px-3 py-1 rounded-full text-xs font-medium transition-colors duration-200"
                     style={{
                       background: isActive ? `color-mix(in srgb, ${accent} 15%, transparent)` : 'transparent',
                       color: isActive ? accent : 'var(--text-muted)',

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -298,7 +298,7 @@ export function Header() {
                 key={link.to}
                 to={link.to}
                 onClick={(e) => handleNavClick(e, link.to)}
-                className="relative px-4 py-2 text-sm font-medium no-underline rounded-lg transition-all duration-150 hover:bg-[var(--bg-raised)]"
+                className="relative px-4 py-2 text-sm font-medium no-underline rounded-lg transition-colors duration-150 hover:bg-[var(--bg-raised)]"
                 style={{
                   color: isActive
                     ? 'var(--text-primary)'

--- a/src/components/report-card/ReportShareCard.tsx
+++ b/src/components/report-card/ReportShareCard.tsx
@@ -169,7 +169,7 @@ export function ReportShareCard({ report }: ReportShareCardProps) {
       <canvas ref={canvasRef} className="hidden" />
       <button
         onClick={handleShare}
-        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-all duration-150 whitespace-nowrap hover:border-[var(--positive)] hover:bg-[rgba(74,222,128,0.08)]"
+        className="py-2 px-4 rounded-lg text-sm font-medium cursor-pointer transition-colors duration-150 whitespace-nowrap hover:border-[var(--positive)] hover:bg-[rgba(74,222,128,0.08)]"
         style={{
           background: status !== 'idle' ? 'var(--positive-dim)' : 'transparent',
           color: status !== 'idle' ? 'var(--positive)' : 'var(--text-secondary)',

--- a/src/components/topics/DeepLinks.tsx
+++ b/src/components/topics/DeepLinks.tsx
@@ -17,7 +17,7 @@ export function DeepLinks({ links }: DeepLinksProps) {
           <Link
             key={link.route}
             to={link.route}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium no-underline transition-all duration-150 hover:brightness-125"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium no-underline transition-[filter] duration-150 hover:brightness-125"
             style={{
               background: `${accent}12`,
               color: accent,

--- a/src/components/topics/TopicCTA.tsx
+++ b/src/components/topics/TopicCTA.tsx
@@ -34,7 +34,7 @@ export function TopicCTA({ links, accent }: TopicCTAProps) {
             >
               <Link
                 to={link.route}
-                className="block h-full rounded-xl p-5 no-underline transition-all duration-200 hover:brightness-125"
+                className="block h-full rounded-xl p-5 no-underline transition-[filter] duration-200 hover:brightness-125"
                 style={{
                   background: 'var(--bg-raised)',
                   borderLeft: `3px solid ${domainAccent}`,

--- a/src/components/topics/TopicCard.tsx
+++ b/src/components/topics/TopicCard.tsx
@@ -30,7 +30,7 @@ export function TopicCard({ topic, bag, index, isVisible = true }: TopicCardProp
     >
       <Link
         to={`/topics/${topic.id}`}
-        className="group block h-full rounded-xl p-5 no-underline transition-all duration-200 hover:brightness-110"
+        className="group block h-full rounded-xl p-5 no-underline transition-[filter] duration-200 hover:brightness-110"
         style={{
           background: 'var(--bg-raised)',
           border: `1px solid ${topic.accent}15`,

--- a/src/components/ui/CrossDomainLink.tsx
+++ b/src/components/ui/CrossDomainLink.tsx
@@ -26,7 +26,7 @@ export function CrossDomainLink({ domain, sectionId }: CrossDomainLinkProps) {
           <Link
             key={`${link.toDomain}-${link.toSection}`}
             to={`${meta.route}#${link.toSection}`}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium no-underline transition-all duration-150 hover:brightness-125"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium no-underline transition-[filter] duration-150 hover:brightness-125"
             style={{
               background: `${meta.accent}12`,
               color: meta.accent,

--- a/src/components/ui/DomainCTA.tsx
+++ b/src/components/ui/DomainCTA.tsx
@@ -105,7 +105,7 @@ export function DomainCTA({ domain }: DomainCTAProps) {
                   <Link
                     key={r.domain}
                     to={meta.route}
-                    className="group flex h-full items-center gap-3 px-4 py-3 rounded-lg no-underline transition-all duration-150 hover:brightness-110"
+                    className="group flex h-full items-center gap-3 px-4 py-3 rounded-lg no-underline transition-[filter] duration-150 hover:brightness-110"
                     style={{
                       background: 'var(--bg-raised)',
                       borderLeft: `3px solid ${meta.accent}`,

--- a/src/components/ui/KeyTakeaways.tsx
+++ b/src/components/ui/KeyTakeaways.tsx
@@ -57,7 +57,7 @@ export function KeyTakeaways({ pills, accent }: KeyTakeawaysProps) {
             >
               {pill.label}
               <span
-                className="inline-block ml-1 opacity-0 -translate-x-1 transition-all duration-200 group-hover:opacity-100 group-hover:translate-x-0"
+                className="inline-block ml-1 opacity-0 -translate-x-1 transition-[opacity,transform] duration-200 group-hover:opacity-100 group-hover:translate-x-0"
                 aria-hidden
               >
                 &rarr;

--- a/src/components/ui/RelatedTopics.tsx
+++ b/src/components/ui/RelatedTopics.tsx
@@ -30,7 +30,7 @@ export function RelatedTopics({ sectionId, domain }: RelatedTopicsProps) {
         <Link
           key={topic.id}
           to={`/topics/${topic.id}`}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium no-underline transition-all duration-150 hover:brightness-125"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium no-underline transition-[filter] duration-150 hover:brightness-125"
           style={{
             background: `${topic.accent}12`,
             color: topic.accent,


### PR DESCRIPTION
## Summary
Replaces every Tailwind `transition-all` with the minimal **explicit** transition utility naming only the properties that actually animate. `transition-all` forces the browser to watch every animatable property and can animate unintended ones — this is the craft/perf cleanup flagged in handoff §5. **Behavior is identical** (same end states, same `duration`/`ease`/`delay`); only the watched property set is narrowed. **Not merged** — for review.

## What changed (19 of 21 instances, 17 files)
Per-instance analysis of each element's `hover:`/`group-hover:`/state classes determined the properties:
- bg / border / color hovers + inline color toggles → `transition-colors`
- `hover:brightness-*` (a CSS **filter**) → `transition-[filter]` — note: `transition-colors` does **not** cover `filter`, so these brightness hovers were silently depending on `transition-all`
- scale + border hovers → `transition-[transform,border-color]`
- group-hover opacity + translate reveals → `transition-[opacity,transform]`
- sticky nav backdrop/bg/border → `transition-[backdrop-filter,background-color,border-color]`

## Left as-is (2, intentional)
`ui/FeedbackButton.tsx` and `pages/ExplorePage.tsx` ("Try Again") have no hover/state classes and fully static inline styles — nothing CSS-animatable changes, so no property can be named. The `transition-all` there is a harmless no-op (entrance is framer-motion-driven); removing vs. keeping is cosmetic, left untouched to avoid risk.

## Verification
- `tsc -b` clean.
- Hub renders correctly at rest (CategoryNav, cards, nav pills — the changed-transition elements).
- For this change class, the meaningful check is property coverage (explicit utilities exactly cover the hover-changed properties — diff-verified) + identical end states; a hover screenshot can't distinguish `transition-all` from the explicit form (same target state, only tween smoothness differs, which is preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)