### PR TITLE
perf: Core Web Vitals instrumentation + numeric performance budget (privacy-preserving)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 *.pyc
 *.egg-info/
 pipeline/reference-pdfs/
+
+# Lighthouse CI output
+.lighthouseci/

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,53 @@
+# Performance budget & monitoring
+
+This site has a numeric performance budget enforced in two places that share the
+same thresholds:
+
+| Metric | Budget (good) | Where |
+|---|---|---|
+| Largest Contentful Paint (LCP) | ≤ 2500 ms | field + lab |
+| Interaction to Next Paint (INP) | ≤ 200 ms | field (lab proxy: TBT ≤ 200 ms) |
+| Cumulative Layout Shift (CLS) | ≤ 0.1 | field + lab |
+| First Contentful Paint (FCP) | ≤ 1800 ms | field + lab |
+| Time to First Byte (TTFB) | ≤ 800 ms | field |
+| Time to Interactive (lab) | ≤ 3800 ms | lab |
+
+These are the official Core Web Vitals "good" boundaries. The single source of
+truth is [`src/lib/perf/budget.ts`](../src/lib/perf/budget.ts); the Lighthouse
+budget ([`lighthouse-budget.json`](../lighthouse-budget.json)) mirrors them.
+
+## Field measurement (real users) — privacy-preserving
+
+`src/lib/perf/webVitals.ts` measures Core Web Vitals in the browser via the
+[`web-vitals`](https://github.com/GoogleChrome/web-vitals) library. It is
+**measure-only and sends nothing to any third party**:
+
+- In dev it logs a rated summary to the console (`[web-vitals] ✓ LCP = 1820ms (good)`).
+- In any environment it buffers the latest reading per metric on
+  `window.__WEB_VITALS__` so it can be inspected from the console or by an
+  end-to-end check.
+- There is no analytics endpoint and no external beacon.
+
+To start collecting field data later, pass a first-party reporter — it is opt-in
+and off by default:
+
+```ts
+initWebVitals((reading) => {
+  navigator.sendBeacon('/your-own-endpoint', JSON.stringify(reading)); // first-party only
+});
+```
+
+## Lab measurement (CI / local) — Lighthouse
+
+`lighthouserc.json` runs Lighthouse against the prerendered `dist/` output for a
+representative set of pages (home, a domain landing, an explore page, a topic
+page) and asserts against the budget. Assertions are **`warn` level** so the
+budget surfaces regressions without hard-failing a build until the team chooses
+to tighten any to `error`.
+
+```bash
+npm run perf:lighthouse   # builds, then runs Lighthouse CI against dist/
+```
+
+(Lighthouse CI is invoked via `npx @lhci/cli` — no committed dependency. The
+`.lighthouseci/` output directory is gitignored.)

--- a/lighthouse-budget.json
+++ b/lighthouse-budget.json
@@ -1,0 +1,23 @@
+[
+  {
+    "path": "/*",
+    "timings": [
+      { "metric": "first-contentful-paint", "budget": 1800 },
+      { "metric": "largest-contentful-paint", "budget": 2500 },
+      { "metric": "interactive", "budget": 3800 },
+      { "metric": "total-blocking-time", "budget": 200 },
+      { "metric": "cumulative-layout-shift", "budget": 0.1 },
+      { "metric": "speed-index", "budget": 3400 }
+    ],
+    "resourceSizes": [
+      { "resourceType": "script", "budget": 500 },
+      { "resourceType": "stylesheet", "budget": 100 },
+      { "resourceType": "image", "budget": 500 },
+      { "resourceType": "font", "budget": 250 },
+      { "resourceType": "total", "budget": 1800 }
+    ],
+    "resourceCounts": [
+      { "resourceType": "third-party", "budget": 5 }
+    ]
+  }
+]

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,34 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "dist",
+      "url": [
+        "http://localhost/index.html",
+        "http://localhost/crime/index.html",
+        "http://localhost/census/explore/index.html",
+        "http://localhost/topics/youth-jobs/index.html"
+      ],
+      "numberOfRuns": 3,
+      "settings": {
+        "budgetPath": "./lighthouse-budget.json"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.95 }],
+        "categories:seo": ["warn", { "minScore": 0.95 }],
+        "categories:best-practices": ["warn", { "minScore": 0.95 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 1800 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 200 }],
+        "interactive": ["warn", { "maxNumericValue": 3800 }]
+      }
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": "./.lighthouseci"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-helmet-async": "^2.0.5",
         "react-router-dom": "^7.13.0",
         "topojson-client": "^3.1.0",
+        "web-vitals": "^4.2.4",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -9324,6 +9325,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build && node scripts/prerender.mjs",
     "build:no-prerender": "tsc -b && vite build && node scripts/inject-og.mjs",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "perf:lighthouse": "npm run build && npx --yes @lhci/cli@0.14.x autorun"
   },
   "dependencies": {
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
@@ -25,6 +26,7 @@
     "react-helmet-async": "^2.0.5",
     "react-router-dom": "^7.13.0",
     "topojson-client": "^3.1.0",
+    "web-vitals": "^4.2.4",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/lib/perf/budget.ts
+++ b/src/lib/perf/budget.ts
@@ -1,0 +1,45 @@
+/**
+ * Performance budget — the single numeric source of truth for this site's
+ * Core Web Vitals targets and rating thresholds.
+ *
+ * Thresholds are the official web-vitals "good / needs-improvement / poor"
+ * boundaries (https://web.dev/articles/vitals). `target` is the budget we
+ * commit to (the upper bound of "good"); a metric over `target` is a
+ * regression worth investigating. The Lighthouse assertions in
+ * `lighthouse-budget.json` / `lighthouserc.json` mirror these numbers so the
+ * lab (Lighthouse) and field (web-vitals) budgets stay in sync.
+ */
+
+export type MetricName = 'LCP' | 'INP' | 'CLS' | 'FCP' | 'TTFB';
+export type Rating = 'good' | 'needs-improvement' | 'poor';
+
+interface Threshold {
+  /** Upper bound of "good" — this is the committed budget. */
+  good: number;
+  /** Above this is "poor"; between good and poor is "needs-improvement". */
+  poor: number;
+  /** Display unit. CLS is unitless; the rest are milliseconds. */
+  unit: 'ms' | '';
+  label: string;
+}
+
+export const PERF_BUDGET: Record<MetricName, Threshold> = {
+  LCP: { good: 2500, poor: 4000, unit: 'ms', label: 'Largest Contentful Paint' },
+  INP: { good: 200, poor: 500, unit: 'ms', label: 'Interaction to Next Paint' },
+  CLS: { good: 0.1, poor: 0.25, unit: '', label: 'Cumulative Layout Shift' },
+  FCP: { good: 1800, poor: 3000, unit: 'ms', label: 'First Contentful Paint' },
+  TTFB: { good: 800, poor: 1800, unit: 'ms', label: 'Time to First Byte' },
+};
+
+/** Rate a metric value against the budget. */
+export function rate(name: MetricName, value: number): Rating {
+  const t = PERF_BUDGET[name];
+  if (value <= t.good) return 'good';
+  if (value <= t.poor) return 'needs-improvement';
+  return 'poor';
+}
+
+/** True if the metric is within (at or under) its committed budget. */
+export function withinBudget(name: MetricName, value: number): boolean {
+  return value <= PERF_BUDGET[name].good;
+}

--- a/src/lib/perf/webVitals.ts
+++ b/src/lib/perf/webVitals.ts
@@ -1,0 +1,82 @@
+/**
+ * Web Vitals instrumentation — privacy-preserving by default.
+ *
+ * Measures the Core Web Vitals (LCP, INP, CLS) plus FCP and TTFB in the field,
+ * rates each against the committed budget (./budget), and:
+ *   - logs a rated summary to the console in dev,
+ *   - buffers the latest reading per metric on `window.__WEB_VITALS__` so it
+ *     can be inspected in any environment (and by an e2e/perf check),
+ *   - sends NOTHING to any third party. There is no analytics endpoint and no
+ *     external beacon. To collect field data later, pass an `onReport` callback
+ *     (e.g. a first-party `navigator.sendBeacon` to your own endpoint) — it is
+ *     opt-in and off by default.
+ *
+ * web-vitals reports each metric possibly multiple times (e.g. CLS/INP update
+ * as the session evolves); we keep the latest value per metric.
+ */
+
+import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from 'web-vitals';
+import { rate, type MetricName } from './budget';
+
+export interface VitalReading {
+  name: MetricName;
+  value: number;
+  rating: ReturnType<typeof rate>;
+  /** web-vitals' own rating, for cross-checking. */
+  navigatorRating: Metric['rating'];
+  delta: number;
+  id: string;
+}
+
+declare global {
+  interface Window {
+    __WEB_VITALS__?: Partial<Record<MetricName, VitalReading>>;
+  }
+}
+
+const isDev = import.meta.env.DEV;
+
+function makeHandler(onReport?: (r: VitalReading) => void) {
+  return (metric: Metric) => {
+    const name = metric.name as MetricName;
+    const reading: VitalReading = {
+      name,
+      value: Math.round((name === 'CLS' ? metric.value * 1000 : metric.value)) / (name === 'CLS' ? 1000 : 1),
+      rating: rate(name, metric.value),
+      navigatorRating: metric.rating,
+      delta: metric.delta,
+      id: metric.id,
+    };
+
+    if (typeof window !== 'undefined') {
+      window.__WEB_VITALS__ = window.__WEB_VITALS__ ?? {};
+      window.__WEB_VITALS__[name] = reading;
+    }
+
+    if (isDev) {
+      const icon = reading.rating === 'good' ? '✓' : reading.rating === 'needs-improvement' ? '⚠' : '✗';
+      // eslint-disable-next-line no-console
+      console.debug(`[web-vitals] ${icon} ${name} = ${reading.value}${name === 'CLS' ? '' : 'ms'} (${reading.rating})`);
+    }
+
+    // Opt-in, first-party only. No-op by default.
+    onReport?.(reading);
+  };
+}
+
+let started = false;
+
+/**
+ * Start measuring Core Web Vitals. Idempotent (safe to call once at startup).
+ * @param onReport optional first-party reporter; omitted = measure-only, no network.
+ */
+export function initWebVitals(onReport?: (r: VitalReading) => void): void {
+  if (started || typeof window === 'undefined') return;
+  started = true;
+  const handle = makeHandler(onReport);
+  onLCP(handle);
+  onINP(handle);
+  onCLS(handle);
+  onFCP(handle);
+  onTTFB(handle);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { MotionConfig } from 'framer-motion';
 import './lib/registry/index.ts'; // Register all chart entries for sharing/embedding
 import './index.css';
 import App from './App.tsx';
+import { initWebVitals } from './lib/perf/webVitals.ts';
 
 const container = document.getElementById('root')!;
 
@@ -28,3 +29,7 @@ if (container.children.length > 0) {
 } else {
   createRoot(container).render(app);
 }
+
+// Core Web Vitals — measure-only, privacy-preserving (no third-party beacon).
+// Pass a first-party reporter to initWebVitals(...) to collect field data later.
+initWebVitals();


### PR DESCRIPTION
## Summary
Adds field + lab performance monitoring with a single shared **numeric budget**, **privacy-preserving by default** (handoff §6). No third-party tracking, no analytics endpoint, no beacon. **Not merged** — for review.

## Numeric budget (official Core Web Vitals "good" boundaries)
Single source of truth in `src/lib/perf/budget.ts`, mirrored in `lighthouse-budget.json`:

| LCP | INP | CLS | FCP | TTFB |
|---|---|---|---|---|
| ≤ 2500 ms | ≤ 200 ms | ≤ 0.1 | ≤ 1800 ms | ≤ 800 ms |

(+ lab proxies: TBT ≤ 200 ms, TTI ≤ 3800 ms, Speed Index ≤ 3400 ms.)

## Field measurement (real users) — `src/lib/perf/webVitals.ts`
Wired into `main.tsx` after hydration. Measures LCP/INP/CLS/FCP/TTFB via the `web-vitals` library and rates each against the budget:
- **dev**: logs a rated summary to the console — verified live: `[web-vitals] ✓ LCP = 1908ms (good)`, `FCP = 1104ms (good)`, `CLS = 0 (good)`, `TTFB = 58ms (good)`.
- **all envs**: buffers the latest reading per metric on `window.__WEB_VITALS__` for inspection.
- **sends nothing externally.** A first-party reporter is opt-in via `initWebVitals(onReport)` (off by default).

## Lab measurement (CI / local) — Lighthouse
`lighthouserc.json` + `lighthouse-budget.json` run Lighthouse over the prerendered `dist/` for representative pages (home, a domain landing, an explore page, a topic page) and assert against the budget. Assertions are **`warn` level** so the budget surfaces regressions without hard-failing builds until you choose to tighten any to `error`. Run with `npm run perf:lighthouse` (invokes `npx @lhci/cli` — no committed dep; `.lighthouseci/` gitignored).

## Notes
`web-vitals@^4.2.4` added as a runtime dep (~2KB, no network of its own; lands in the index chunk with negligible weight). Docs in `docs/PERFORMANCE.md`. `tsc -b` + `vite build` clean; browser-verified the metrics fire and rate correctly. Thresholds are the standard CWV "good" values — adjust in `budget.ts` (+ the mirror) if you want different targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)