### PR TITLE
data(environment): reconcile curated corrections + live MOSPI energy (supersedes #112, #118)

### DIFF
--- a/pipeline/src/environment/sources/curated.py
+++ b/pipeline/src/environment/sources/curated.py
@@ -113,9 +113,9 @@ CPCB_AQI_CITIES = [
 # Verified 2026-03-05 by reading every state chapter from the 382-page PDF.
 
 FSI_FOREST_STATES = [
-    {"id": "MP", "name": "Madhya Pradesh", "forestCoverKm2": 77073, "pctGeographicArea": 25.11, "changeKm2": -371.54},
+    {"id": "MP", "name": "Madhya Pradesh", "forestCoverKm2": 77073, "pctGeographicArea": 25.00, "changeKm2": -371.54},
     {"id": "AR", "name": "Arunachal Pradesh", "forestCoverKm2": 65882, "pctGeographicArea": 78.67, "changeKm2": -91.17},
-    {"id": "CG", "name": "Chhattisgarh", "forestCoverKm2": 55812, "pctGeographicArea": 41.21, "changeKm2": -19.13},
+    {"id": "CG", "name": "Chhattisgarh", "forestCoverKm2": 55812, "pctGeographicArea": 41.28, "changeKm2": -19.13},
     {"id": "MH", "name": "Maharashtra", "forestCoverKm2": 50859, "pctGeographicArea": 16.53, "changeKm2": -54.47},
     {"id": "OD", "name": "Odisha", "forestCoverKm2": 52434, "pctGeographicArea": 33.68, "changeKm2": 151.89},
     {"id": "KA", "name": "Karnataka", "forestCoverKm2": 39254, "pctGeographicArea": 20.47, "changeKm2": 147.70},
@@ -199,8 +199,8 @@ CEA_ENERGY_MIX = [
     },
     {
         "year": "2024",
-        "coal": 213950, "gas": 24824, "nuclear": 7480, "hydro": 47073,
-        "solar": 82788, "wind": 46160, "biomass": 10544, "smallHydro": 5011,
+        "coal": 210969, "gas": 25038, "nuclear": 8180, "hydro": 46928,
+        "solar": 81814, "wind": 46160, "biomass": 10544, "smallHydro": 5011,
     },
 ]
 
@@ -269,9 +269,9 @@ CGWB_GROUNDWATER_STATES = [
 
 NATIONAL_TOTALS = {
     "co2PerCapita": 1.9,                # tonnes, World Bank 2021
-    "forestPct": 25.17,                  # ISFR 2023
+    "forestPct": 21.76,                  # ISFR 2023 forest cover (7,15,343 km2). NOTE: 25.17% is forest+TREE cover; forest cover alone is 21.76%.
     "renewablesPct": 43.4,              # CEA Mar 2024 (solar+wind+hydro+bio+smallHydro / total)
     "pm25": 53.3,                        # μg/m3, World Bank 2021
-    "coalPct": 48.8,                    # CEA Mar 2024 (coal / total installed capacity)
+    "coalPct": 47.73,                   # CEA 31.03.2024 (coal-only / 441,970 MW grand total)
     "ghgTotal": 3347.9,                 # Mt CO2e, World Bank 2021
 }

--- a/pipeline/src/environment/transform/energy.py
+++ b/pipeline/src/environment/transform/energy.py
@@ -50,11 +50,17 @@ def build_energy(
         "fuelCapacityMix": fuel_capacity,
     }
 
-    # Add MOSPI energy supply data if available (KToE by commodity)
+    # MOSPI energy supply (KToE by commodity). Always emit energySupply as a
+    # list — never omit the key — so the writer's last-known-good preservation
+    # (_preserve_nonempty_series) protects it: if MOSPI is unreachable this run,
+    # an empty list lets the previously published series be restored instead of
+    # the field silently vanishing from the open-data endpoint.
+    result["energySupply"] = mospi_energy or []
     if mospi_energy:
-        result["energySupply"] = mospi_energy
         sources.insert(0, "MOSPI Energy API (api.mospi.gov.in)")
         logger.info(f"  MOSPI energy supply: {len(mospi_energy)} commodities added")
+    else:
+        logger.info("  MOSPI energy supply unavailable — emitting [] (writer will preserve last-known-good)")
 
     result["source"] = " + ".join(sources)
     return result

--- a/public/data/environment/2025-26/energy.json
+++ b/public/data/environment/2025-26/energy.json
@@ -491,5 +491,34 @@
       "smallHydro": 5011
     }
   ],
-  "source": "World Bank + CEA Installed Capacity Reports"
+  "energySupply": [
+    {
+      "commodity": "Coal",
+      "commodityCode": "coal",
+      "year": "2023-24",
+      "production": 403799.5,
+      "imports": 141638.8,
+      "totalSupply": 534098.3,
+      "unit": "KToE"
+    },
+    {
+      "commodity": "Natural Gas",
+      "commodityCode": "gas",
+      "year": "2023-24",
+      "production": 33704.7,
+      "imports": 29410.3,
+      "totalSupply": 63115.0,
+      "unit": "KToE"
+    },
+    {
+      "commodity": "Lignite",
+      "commodityCode": "lignite",
+      "year": "2023-24",
+      "production": 9786.1,
+      "imports": 11.9,
+      "totalSupply": 9723.0,
+      "unit": "KToE"
+    }
+  ],
+  "source": "MOSPI Energy API (api.mospi.gov.in) + World Bank + CEA Installed Capacity Reports"
 }

--- a/public/data/environment/2025-26/energy.json
+++ b/public/data/environment/2025-26/energy.json
@@ -481,11 +481,11 @@
     },
     {
       "year": "2024",
-      "coal": 213950,
-      "gas": 24824,
-      "nuclear": 7480,
-      "hydro": 47073,
-      "solar": 82788,
+      "coal": 210969,
+      "gas": 25038,
+      "nuclear": 8180,
+      "hydro": 46928,
+      "solar": 81814,
       "wind": 46160,
       "biomass": 10544,
       "smallHydro": 5011

--- a/public/data/environment/2025-26/forest.json
+++ b/public/data/environment/2025-26/forest.json
@@ -255,7 +255,7 @@
       "id": "MP",
       "name": "Madhya Pradesh",
       "forestCoverKm2": 77073,
-      "pctGeographicArea": 25.11,
+      "pctGeographicArea": 25.0,
       "changeKm2": -371.54
     },
     {
@@ -269,7 +269,7 @@
       "id": "CG",
       "name": "Chhattisgarh",
       "forestCoverKm2": 55812,
-      "pctGeographicArea": 41.21,
+      "pctGeographicArea": 41.28,
       "changeKm2": -19.13
     },
     {

--- a/public/data/environment/2025-26/indicators.json
+++ b/public/data/environment/2025-26/indicators.json
@@ -169,7 +169,7 @@
         {
           "id": "MP",
           "name": "Madhya Pradesh",
-          "value": 25.11
+          "value": 25.0
         },
         {
           "id": "AR",
@@ -179,7 +179,7 @@
         {
           "id": "CG",
           "name": "Chhattisgarh",
-          "value": 41.21
+          "value": 41.28
         },
         {
           "id": "MH",

--- a/public/data/environment/2025-26/summary.json
+++ b/public/data/environment/2025-26/summary.json
@@ -1,11 +1,11 @@
 {
   "year": "2025-26",
   "co2PerCapita": 1.9,
-  "forestPct": 25.17,
+  "forestPct": 21.76,
   "renewablesPct": 43.4,
   "pm25": 53.3,
-  "coalPct": 48.8,
+  "coalPct": 47.73,
   "ghgTotal": 3347.9,
-  "lastUpdated": "2026-04-15",
+  "lastUpdated": "2026-06-03",
   "source": "World Bank + CPCB + ISFR 2023 + CEA + CWC + CGWB"
 }


### PR DESCRIPTION
## What

One coordinated environment PR that **supersedes both #112 and #118** (close those as incorporated), the way crime #127 folded in #119/#124.

### From #118 — curated corrections (double-verified vs primary sources)
| Field | Old | New | Source |
|---|---|---|---|
| `forestPct` | 25.17 | **21.76** | ISFR 2023 forest cover alone (7,15,343 km²). 25.17% is forest **+ tree** cover. |
| `coalPct` | 48.8 | **47.73** | CEA 31.03.2024, coal-only / 441,970 MW grand total |
| CEA 2024 coal | 213950 | 210969 | CEA Installed Capacity Mar 2024 |
| CEA 2024 gas | 24824 | 25038 | " |
| CEA 2024 nuclear | 7480 | 8180 | " |
| CEA 2024 hydro | 47073 | 46928 | " |
| CEA 2024 solar | 82788 | 81814 | " |
| MP forest % | 25.11 | 25.00 | ISFR 2023 Vol II |
| CG forest % | 41.21 | 41.28 | ISFR 2023 Vol II |

### From #112 — live MOSPI Energy API
- `energy.json` gains `energySupply[]`: Coal / Natural Gas / Lignite — production, imports, totalSupply (KToE, 2023-24) from `api.mospi.gov.in`.
- `energy.json` source line credits the MOSPI Energy API.

## Verification
- `energy.json` and `summary.json` both validate against the Pydantic schemas (`EnergyData`, `EnvironmentSummary`).
- No frontend code change — `energySupply` is an open-data field (not yet rendered); the forest/coal corrections flow through existing components.

## Merge notes
- **Supersedes #112 and #118** — close both as incorporated.
- Touches `environment/curated.py` + `indicators.json` on different lines than the **AQI-removal PR** (CPCB block / `state_aqi` indicator). They 3-way auto-merge; if both are taken, merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)